### PR TITLE
Lab mark as read

### DIFF
--- a/ServerSide/Api.php
+++ b/ServerSide/Api.php
@@ -136,9 +136,9 @@ if (isset($_GET['apicall'])) {
         break;
 
         case 'markAsRead':
-            $response = isTheseParametersAvailable(array('messageID', 'userID'));
+            $response = isTheseParametersAvailable(array('messageID', 'userID', 'isResponse'));
             if (!$response['error']){
-               $response = $oper->markAsRead($_POST['messageID'], $_POST['userID']);
+               $response = $oper->markAsRead($_POST['messageID'], $_POST['userID'], $_POST['isResponse']);
             }
         break;
 

--- a/ServerSide/DbOperations.php
+++ b/ServerSide/DbOperations.php
@@ -63,7 +63,7 @@ class DbOperations
 							'dept_type' => $deptType
 						);
 
-						$stmt1->close();
+						$stmt->close();
 						//adding the user data in response
 						$response['error'] = false;
 						$response['message'] = 'משתמש נרשם בהצלחה';
@@ -207,20 +207,20 @@ class DbOperations
         }
         return $response;
     }
-
+    
       function getNotActive(){
         $response = array();
         $stmt = $this->conn->prepare('SELECT `full_name`, `employee_ID`, `role`, `works_in_dept` FROM users WHERE `is_active`=0');
 		$stmt->execute();
 		$stmt->store_result();
 		$rows = $stmt->num_rows;
-
+		
 		 if ($stmt->num_rows > 0){
-
+		  
 		      while ($rows>0){
 		        $stmt->bind_result($fullName, $employeeNumber, $jobTitle, $deptID);
                 $stmt->fetch();
-
+                
                 $users[$stmt->num_rows-$rows] = array('full_name' => $fullName,
 				'employee_ID' => $employeeNumber,
 				'role' => $jobTitle,
@@ -236,7 +236,7 @@ class DbOperations
 		     $response['error'] = false;
 		     $response['message']="אין משתמשים הממתינים לאישור";
 		 }
-
+		 
 		 return $response;
     }
 
@@ -541,13 +541,19 @@ class DbOperations
         return $response;
     }
 
-    function markAsRead($messageID, $userID){
+    function markAsRead($messageID, $userID, $isResponse){
         $response = array();
         // Query to add a confirmation user and time
+        if (!$isResponse)
         $stmtMark = $this->conn->prepare("UPDATE messages SET confirm_time = CURRENT_TIMESTAMP, confirm_user = ? WHERE messages.ID = ?;");
+        else 
+        $stmtMark = $this->conn->prepare("UPDATE responses SET confirm_time = CURRENT_TIMESTAMP, confirm_user = ? WHERE responses.ID = ?;");
         $stmtMark->bind_param("si", $userID, $messageID);
         // Query to check whether the message had already been marked by another user
+        if (!$isResponse)
         $stmtCheck = $this->conn->prepare("SELECT confirm_user FROM messages WHERE confirm_user IS NULL AND ID = ?");
+        else
+        $stmtCheck = $this->conn->prepare("SELECT confirm_user FROM responses WHERE confirm_user IS NULL AND ID = ?");
         $stmtCheck->bind_param("i",$messageID);
         $stmtCheck->execute();
         $stmtCheck->store_result();

--- a/app/src/main/java/il/reportap/AdapterActivityInboxLab.java
+++ b/app/src/main/java/il/reportap/AdapterActivityInboxLab.java
@@ -1,101 +1,214 @@
 package il.reportap;
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
+import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
-import android.graphics.PorterDuff;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
+import android.widget.Button;
+import android.widget.ImageButton;
 import android.widget.TextView;
+import android.widget.Toast;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
-import androidx.core.content.ContextCompat;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.android.volley.AuthFailureError;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
+import com.android.volley.toolbox.Volley;
 import com.example.loginregister.R;
 
-import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
 
-public class AdapterActivityInboxLab extends RecyclerView.Adapter<AdapterActivityInboxLab.ViewHolder>{
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AdapterActivityInboxLab extends RecyclerView.Adapter<AdapterActivityInboxLab.ViewHolder> {
     private List<ModelActivityInboxLab> modelActivityInboxLabList;
     private Context context;
+    private Boolean successMarkRead;
 
     public AdapterActivityInboxLab(List<ModelActivityInboxLab> modelActivityInboxLabList, Context context) {
         this.modelActivityInboxLabList = modelActivityInboxLabList;
         this.context = context;
+        this.successMarkRead = false;
     }
 
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.row_layout_inbox_lab,parent,false);
+                .inflate(R.layout.row_layout_inbox_lab, parent, false);
         return new ViewHolder(v);
     }
 
     @SuppressLint("ResourceAsColor")
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-            ModelActivityInboxLab modelActivityInboxLab = modelActivityInboxLabList.get(position);
+        ModelActivityInboxLab modelActivityInboxLab = modelActivityInboxLabList.get(position);
 
-            holder.sentTime.setText(modelActivityInboxLab.getSentTime());
-            holder.patientId.setText(modelActivityInboxLab.getPatientId());
-            holder.testName.setText(modelActivityInboxLab.getTestName());
-            holder.text.setText(modelActivityInboxLab.getText());
-            holder.component.setText(modelActivityInboxLab.getComponent());
-            holder.fullName.setText(modelActivityInboxLab.getFullName());
-            holder.deptName.setText(modelActivityInboxLab.getDept());
-            holder.measurement.setText(modelActivityInboxLab.getMeasurement());
-       //     holder.messageID = modelActivityInboxLab.getId();
-//            holder.cardView.setOnClickListener(new View.OnClickListener() {
-//                @Override
-//                public void onClick(View v) {
-//                    Intent intent = new Intent(context, ViewMessage.class);
-//                    intent.putExtra("MESSAGE_ID", holder.messageID);
-//                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-//                    context.startActivity(intent);
-//                }
-//            });
-            if(modelActivityInboxLab.getIsValueBool()==1)
-            {
-                holder.measurement.setVisibility(View.INVISIBLE);
-                if(Float.valueOf(modelActivityInboxLab.getResultValue())==1)
-                {
-                    holder.resultValue.setText(": חיובי");
+        holder.sentTime.setText(modelActivityInboxLab.getSentTime());
+        holder.patientId.setText(modelActivityInboxLab.getPatientId());
+        holder.testName.setText(modelActivityInboxLab.getTestName());
+        holder.text.setText(modelActivityInboxLab.getText());
+        holder.component.setText(modelActivityInboxLab.getComponent());
+        holder.fullName.setText(modelActivityInboxLab.getFullName());
+        holder.deptName.setText(modelActivityInboxLab.getDept());
+        holder.measurement.setText(modelActivityInboxLab.getMeasurement());
+        holder.responseID = modelActivityInboxLab.getId();
+
+        //Begin defining mark-as-read button response
+        if (modelActivityInboxLab.getWasRead())             // If the message was read (the row is in DoneLab page) -> hide the eye button
+            holder.wasReadButton.setVisibility(View.GONE);
+        else {                                              // If the message wasn't read (the row is in InboxLab page) -> prepare the eye button and confirmation box
+            holder.wasReadButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    showConfirmationBox(holder);
                 }
-                else holder.resultValue.setText(": שלילי");
-            }
-            else
-            {
-                holder.resultValue.setText(Float.toString(modelActivityInboxLab.getResultValue()));
-            }
-      }
+            });
+            holder.confirmationBox.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+                @Override
+                public void onFocusChange(View v, boolean hasFocus) {
+                    hideConfirmationBox(holder);
+                }
+            });
+            holder.confirmRead.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    hideConfirmationBox(holder);
+                    markAsRead(holder.responseID, SharedPrefManager.getInstance(context.getApplicationContext()).getUser().getEmployeeNumber(), holder);
+                }
+            });
+            holder.cancelRead.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    hideConfirmationBox(holder);
+                }
+            });
+        }
+        //End defining mark-as-read button response
+
+        if (modelActivityInboxLab.getIsValueBool() == 1) {
+            holder.measurement.setVisibility(View.INVISIBLE);
+            if (Float.valueOf(modelActivityInboxLab.getResultValue()) == 1) {
+                holder.resultValue.setText(": חיובי");
+            } else holder.resultValue.setText(": שלילי");
+        } else {
+            holder.resultValue.setText(Float.toString(modelActivityInboxLab.getResultValue()));
+        }
+    }
 
     @Override
     public int getItemCount() {
         return modelActivityInboxLabList.size();
     }
 
-    public class ViewHolder extends RecyclerView.ViewHolder{
+    public class ViewHolder extends RecyclerView.ViewHolder {
 
-        public TextView sentTime, patientId,testName, text, measurement, component,resultValue, fullName,deptName;
- //       public Integer messageID;
-  //      public CardView cardView;
+        public TextView sentTime, patientId, testName, text, measurement, component, resultValue, fullName, deptName;
+        public Integer responseID;
+        public ImageButton wasReadButton;
+        public ConstraintLayout confirmationBox;
+        public Button confirmRead, cancelRead;
+        public CardView cardView;
 
         public ViewHolder(View itemView) {
             super(itemView);
 
-  //          cardView = (CardView)itemView.findViewById(R.id.card_view);
-            sentTime = (TextView)itemView.findViewById(R.id.sentTimeL);
-            patientId = (TextView)itemView.findViewById(R.id.patientIdL);
-            testName = (TextView)itemView.findViewById(R.id.testNameL);
-            text=(TextView)itemView.findViewById(R.id.messageTextL);
-            measurement=(TextView)itemView.findViewById(R.id.valueType);
-            component=(TextView)itemView.findViewById(R.id.component);
-            resultValue=(TextView)itemView.findViewById(R.id.resValue);
-            fullName=(TextView)itemView.findViewById(R.id.senderuser);
-            deptName=(TextView)itemView.findViewById(R.id.senderdept);
-
+            sentTime = (TextView) itemView.findViewById(R.id.sentTimeL);
+            patientId = (TextView) itemView.findViewById(R.id.patientIdL);
+            testName = (TextView) itemView.findViewById(R.id.testNameL);
+            text = (TextView) itemView.findViewById(R.id.messageTextL);
+            measurement = (TextView) itemView.findViewById(R.id.valueType);
+            component = (TextView) itemView.findViewById(R.id.component);
+            resultValue = (TextView) itemView.findViewById(R.id.resValue);
+            fullName = (TextView) itemView.findViewById(R.id.senderuser);
+            deptName = (TextView) itemView.findViewById(R.id.senderdept);
+            wasReadButton = (ImageButton) itemView.findViewById(R.id.eyeCheckedIL);
+            confirmationBox = itemView.findViewById(R.id.confirmationBox);
+            confirmRead = itemView.findViewById(R.id.buttonConfirmMarkRead);
+            cancelRead = itemView.findViewById(R.id.buttonCancelMarkRead);
+            cardView = itemView.findViewById(R.id.card_view);
         }
+    }
+
+    public void showConfirmationBox(ViewHolder viewHolder) {
+        if (viewHolder.confirmationBox.getVisibility() == View.GONE)
+            viewHolder.confirmationBox.setVisibility(View.VISIBLE);
+        else
+            viewHolder.confirmationBox.setVisibility(View.GONE);
+    }
+
+    public void hideConfirmationBox(ViewHolder viewHolder) {
+        viewHolder.confirmationBox.setVisibility(View.GONE);
+    }
+
+    public void markAsRead(Integer messageID, String userID, ViewHolder viewHolder) {   // This method doesn't return a value (impossible to return inside an onClick() method) but changes the global variable successMarkRead according to success.
+        successMarkRead = false;
+        StringRequest stringRequest = new StringRequest(Request.Method.POST, URLs.URL_MARK_AS_READ, new Response.Listener<String>() {
+            @Override
+            public void onResponse(String response) {
+                try {
+                    JSONObject jsonObject = new JSONObject(response);
+                    successMarkRead = !jsonObject.getBoolean("error");
+                    if (!successMarkRead) {
+                        Toast.makeText(context.getApplicationContext(), jsonObject.getString("message"), Toast.LENGTH_LONG).show(); // Show a message whether the operation succeeded or the error message
+                        if (jsonObject.getBoolean("alreadyMarked")) {    // If the message had already been marked by another user, the function will also mark success TRUE and disable the button to mark again
+                            successMarkRead = true;
+                        }
+                    } else {
+                        Toast.makeText(context.getApplicationContext(), "ההודעה אושרה בהצלחה!", Toast.LENGTH_LONG).show();
+                    }
+                } catch (JSONException e) {
+                    Toast.makeText(context.getApplicationContext(), e.getMessage(), Toast.LENGTH_LONG).show();
+                    e.printStackTrace();
+                } finally {
+                    if (successMarkRead) {
+                        AnimatorListenerAdapter afterSlideAway = new AnimatorListenerAdapter() {
+                            @Override
+                            public void onAnimationEnd(Animator animation) {    // Refresh the inbox page after animation is done
+                                super.onAnimationEnd(animation);
+                                Intent intent = new Intent(context.getApplicationContext(), InboxLab.class);
+                                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                                context.startActivity(intent);
+                            }
+                        };
+                        viewHolder.cardView.animate().translationX(viewHolder.cardView.getWidth()).alpha(0.0f).setListener(afterSlideAway); // Animate the message row out of screen bounds, then refresh inbox
+                    }
+                }
+            }
+        },
+                new Response.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        Toast.makeText(context.getApplicationContext(), error.getMessage(), Toast.LENGTH_LONG).show();
+                    }
+                }) {
+            @Nullable
+            @Override
+            protected Map<String, String> getParams() throws AuthFailureError {
+                Map<String, String> params = new HashMap<>();
+                params.put("messageID", messageID.toString());
+                params.put("userID", userID);
+                params.put("isResponse", "true");
+                return params;
+            }
+        };
+        RequestQueue requestQueue = Volley.newRequestQueue(context.getApplicationContext());
+        requestQueue.add(stringRequest);
     }
 }

--- a/app/src/main/java/il/reportap/DoneLab.java
+++ b/app/src/main/java/il/reportap/DoneLab.java
@@ -111,7 +111,8 @@ public class DoneLab extends ButtonsOptions {
                                     jObg.getInt("is_value_bool"),
                                     Float.valueOf((float) jObg.getDouble("result_value")),
                                     jObg.getString("full_name"),
-                                    jObg.getString("dept_name"));
+                                    jObg.getString("dept_name"),
+                                    true);
                             modelActivityInboxLabList.add(modelActivityInboxLab);
                         }
 

--- a/app/src/main/java/il/reportap/InboxLab.java
+++ b/app/src/main/java/il/reportap/InboxLab.java
@@ -109,7 +109,8 @@ public class InboxLab extends ButtonsOptions {
                                     jObg.getInt("is_value_bool"),
                                     Float.valueOf((float) jObg.getDouble("result_value")),
                                     jObg.getString("full_name"),
-                                    jObg.getString("dept_name"));
+                                    jObg.getString("dept_name"),
+                                    false);
                             modelActivityInboxLabList.add(modelActivityInboxLab);
                         }
 

--- a/app/src/main/java/il/reportap/ModelActivityInboxLab.java
+++ b/app/src/main/java/il/reportap/ModelActivityInboxLab.java
@@ -1,13 +1,16 @@
 package il.reportap;
 
+import java.time.LocalDateTime;
+
 public class ModelActivityInboxLab {
     private Integer id,messageId,isValueBool;
     private String sentTime,patientId,testName,text,measurement,component, fullName, dept;
     private Float resultValue;
+    private Boolean wasRead;
 
     public ModelActivityInboxLab(Integer id,Integer messageId, String sentTime, String patientId, String testName,
                                  String text, String measurement, String component, Integer isValueBool, Float resultValue,
-                                 String fullName, String dept) {
+                                 String fullName, String dept, Boolean wasRead) {
         this.id = id;
         this.messageId=messageId;
         this.sentTime = sentTime;
@@ -20,6 +23,7 @@ public class ModelActivityInboxLab {
         this.resultValue=resultValue;
         this.fullName=fullName;
         this.dept=dept;
+        this.wasRead=wasRead;
     }
 
     public Integer getId(){return id;}
@@ -31,6 +35,7 @@ public class ModelActivityInboxLab {
     public String getPatientId() {
         return patientId;
     }
+
     public String getTestName() {
         return testName;
     }
@@ -66,5 +71,8 @@ public class ModelActivityInboxLab {
     public String getDept() {
         return dept;
     }
+
+    public Boolean getWasRead() { return wasRead; }
+
 }
 

--- a/app/src/main/java/il/reportap/ViewMessage.java
+++ b/app/src/main/java/il/reportap/ViewMessage.java
@@ -321,6 +321,7 @@ public class ViewMessage extends ButtonsOptions {
                         Map<String, String> params = new HashMap<>();
                         params.put("messageID",messageID.toString());
                         params.put("userID",userID);
+                        params.put("isResponse", "false");
                         return params;
                     }
                 };

--- a/app/src/main/res/layout/row_layout_inbox_lab.xml
+++ b/app/src/main/res/layout/row_layout_inbox_lab.xml
@@ -5,7 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/card_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:inputType="textNoSuggestions"
+    android:animateLayoutChanges="true">
 
 
     <LinearLayout
@@ -63,6 +65,28 @@
                 card_view:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/eyeCheckedIL"
+            android:layout_width="62dp"
+            android:layout_height="wrap_content"
+            android:scaleType="fitCenter"
+            android:adjustViewBounds="true"
+            android:tooltipText="לחצו כדי לסמן כנקרא"
+            android:layout_marginHorizontal="5dp"
+            android:hapticFeedbackEnabled="true"
+            android:background="?android:selectableItemBackground"
+            android:padding="5dp"
+            card_view:srcCompat="@drawable/eye"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -118,11 +142,53 @@
                 card_view:layout_constraintTop_toTopOf="parent"
                 tools:ignore="MissingConstraints" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-
+        </LinearLayout>
+    </LinearLayout>
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="5dp">
+            <!-- Confirmation box -->
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/confirmationBox"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                card_view:layout_constraintLeft_toLeftOf="parent"
+                card_view:layout_constraintTop_toTopOf="parent"
+                android:visibility="visible">
+            <TextView
+                android:id="@+id/textViewMarkReadLine1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                card_view:layout_constraintTop_toTopOf="parent"
+                card_view:layout_constraintLeft_toLeftOf="parent"
+                android:text="האם לסמן שהדיווח נקרא?"/>
+            <TextView
+                android:id="@+id/textViewMarkReadLine2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                card_view:layout_constraintTop_toBottomOf="@id/textViewMarkReadLine1"
+                card_view:layout_constraintLeft_toLeftOf="parent"
+                android:text="לא ניתן לבטל טיפול בדיווח"
+                android:textStyle="bold"/>
+            <Button
+                android:id="@+id/buttonConfirmMarkRead"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="אישור"
+                card_view:layout_constraintTop_toBottomOf="@id/textViewMarkReadLine2"
+                card_view:layout_constraintLeft_toLeftOf="parent"/>
+            <Button
+                android:id="@+id/buttonCancelMarkRead"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="ביטול"
+                card_view:layout_constraintTop_toBottomOf="@id/textViewMarkReadLine2"
+                card_view:layout_constraintLeft_toRightOf="@id/buttonConfirmMarkRead"
+                android:layout_marginLeft="5dp"
+                android:backgroundTint="@color/disabled_background"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <!-- End Confirmation box -->
 
             <TextView
                 android:id="@+id/senderdept"


### PR DESCRIPTION
Added mark-as-read to lab inboxes
- Eye button on InboxLab
- Confirmation dialog
- Marking a message triggers an animation slide-out and then refreshes the inbox
- Altered server-side function to support mark-as-read for responses as well as for messages
- Eye button is hidden on DoneLab (as all messages here are done)