### PR TITLE
Sending a reply now marks-as-read properly

### DIFF
--- a/app/src/main/res/layout/activity_view_message.xml
+++ b/app/src/main/res/layout/activity_view_message.xml
@@ -164,28 +164,30 @@
             android:gravity="center"
             android:visibility="visible">
             <TextView
+                android:id="@+id/textViewMeasuredAmountTitle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.2"
                 android:text="כמות נמדדת:" />
-            <TextView
-                android:id="@+id/textViewMeasuredAmount"
+            <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.15"
-                android:ems="10"
-                android:gravity="right" />
-            <TextView
-                android:id="@+id/textViewMeasurementUnit"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.1"
-                android:gravity="right" />
-            <Space
-                android:id="@+id/spacerMeasuredAmount"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.35" />
+                android:orientation="horizontal"
+                android:layout_weight="0.6">
+                <TextView
+                    android:id="@+id/textViewMeasuredAmount"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="right" />
+                <Space
+                    android:layout_width="3dp"
+                    android:layout_height="wrap_content"/>
+                <TextView
+                    android:id="@+id/textViewMeasurementUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="right" />
+            </LinearLayout>
         </LinearLayout>
 
         <!-- Boolean results alternative -->
@@ -206,13 +208,16 @@
                 android:id="@+id/textViewBoolResult"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.3" />
+                android:layout_weight="0.3"
+                android:textStyle="bold" />
             <Space
                 android:id="@+id/spacerBoolResult"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.3" />
         </LinearLayout>
+
+        <!-- Comments -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
- Extracted markAsRead() logic to a separate method
and created assignMarkAsReadConfirmation which connects the logic with the confirmation-dialog handler.
- Minor UI improvements in activity_view_message.xml